### PR TITLE
6 api/login api/logout

### DIFF
--- a/app/controller/router.go
+++ b/app/controller/router.go
@@ -11,5 +11,6 @@ func GetRouter() *gin.Engine{
 	r.POST("/api/admin/users/create",CreateUsers)
 	r.GET("/api/equipments/", GetEquipments)
 	r.POST("api/login",Login)
+	r.POST("api/logout",Logout)
 	return r
 }

--- a/app/controller/router.go
+++ b/app/controller/router.go
@@ -10,5 +10,6 @@ func GetRouter() *gin.Engine{
 	r.GET("/api/admin/users", GetUsers)
 	r.POST("/api/admin/users/create",CreateUsers)
 	r.GET("/api/equipments/", GetEquipments)
+	r.POST("api/login",Login)
 	return r
 }

--- a/app/controller/router.go
+++ b/app/controller/router.go
@@ -1,16 +1,47 @@
 package controller
 
-import(
+import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 )
 
 func GetRouter() *gin.Engine{
 	r := gin.Default()
 	r.LoadHTMLGlob("view/*html")
-	r.GET("/api/admin/users", GetUsers)
+	r.GET("/api/admin/users",CheckAuth, GetUsers)
 	r.POST("/api/admin/users/create",CreateUsers)
 	r.GET("/api/equipments/", GetEquipments)
-	r.POST("api/login",Login)
-	r.POST("api/logout",Logout)
+	r.POST("/api/login",Login)
+	r.POST("/api/logout",Logout)
 	return r
+}
+
+// 各処理の前に認可情報を確認するためのメソッド
+// GetRouterの各メソッドのパス後の引数として本メソッドを追加することで認可処理の対象となる
+// /api/adminが含まれている場合はadmin権限が必要
+// user権限の場合はセッションIDを保持していることのみを認可条件としている
+func CheckAuth(c *gin.Context){
+	// セッションIDがなかった場合403を返し、処理が中断される
+	sessionId,err:=c.Cookie("session_id")
+	if err != nil {
+		c.JSON(403,"session情報がありません")
+		c.Abort()
+		return
+	}
+	// サーバーに保存されているセッション情報とリクエストされたセッション情報を比較する
+	// admin権限を持っている場合/api/adminを含むパスを認可する
+	// 権限がなかった場合403を返し、処理が中断される
+	sessionMutex.Lock()
+	role := sessions[sessionId]
+	if strings.HasPrefix(c.Request.URL.Path, "/api/admin") && role != "admin" {
+		c.JSON(403,"権限が不足しています")
+		c.Abort()
+		sessionMutex.Unlock()
+		return
+	}
+	sessionMutex.Unlock()
+
+	// 認可が成功されたため、後続の処理を実行する
+	c.Next()
 }

--- a/app/controller/user_controller.go
+++ b/app/controller/user_controller.go
@@ -118,3 +118,24 @@ func generateSessionID() (string, error) {
 	sessionID := base64.URLEncoding.EncodeToString(randomBytes)
 	return sessionID, nil
 }
+
+func Logout(c *gin.Context) {
+	// CookieからセッションIDを取得し、サーバーサイドでセッションを削除
+	cookie, err := c.Cookie("session_id")
+	fmt.Print(cookie)
+	if err == nil {
+		sessionMutex.Lock()
+		delete(sessions, cookie)
+		sessionMutex.Unlock()
+	}
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:   "session_id",
+		Value:  "",
+		Path:   "/",
+		MaxAge: -1, // Cookieを削除
+	})
+
+	message := ResponseMessage{Message: "適切にログアウトされました"}
+	c.JSON(200,message)
+}

--- a/app/controller/user_controller.go
+++ b/app/controller/user_controller.go
@@ -2,9 +2,23 @@ package controller
 
 import (
 	"app/service"
+	"fmt"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator"
 )
+
+// ログイン情報
+type LoginInformation struct {
+	Email string `json:"email" validate:"email"`
+	Password string `json:"password" validate:"required"`
+}
+
+// レスポンスメッセージ格納用
+type ResponseMessage struct {
+	Message string `json:"message"`
+}
 
 // ユーザー一覧を取得するためのメソッド
 // ユーザーが存在する場合はユーザー情報をリストにして200で返す
@@ -16,5 +30,46 @@ func GetUsers(c *gin.Context){
 		c.IndentedJSON(404, users)
 	default:
 		c.IndentedJSON(200, users)
+	}
+}
+
+// ログイン処理のためのメソッド
+//　ログイン情報を受け取りログイン処理を実施する
+// バリデーションとしてemailはemail形式,passwordは入力必須とした
+// ログイン成功時200を返す（認証情報については後ほど追記する）
+// 入力形式が不適切の場合400を返す
+// 入力値が不適切であれば403を返す
+func Login(c *gin.Context){
+	var loginInformation LoginInformation
+	if err := c.ShouldBindJSON(&loginInformation); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 以下バリデーション実装
+	validate = validator.New()
+	validateErr := validate.Struct(loginInformation)
+	if validateErr!=nil{
+		for _, err := range validateErr.(validator.ValidationErrors) {
+			fmt.Println("Namespace =",err.Namespace())
+			fmt.Println("Tag =",err.Tag())
+			fmt.Println("Type =",err.Type())
+			fmt.Println("Value =",err.Value())
+			fmt.Println("Param =",err.Param())
+		}
+		errorMessage :=ResponseMessage{Message: "ログインが失敗しました"}
+		c.IndentedJSON(400, errorMessage)
+	}else{
+		//ログイン処理を呼び出す
+		err:=service.Login(loginInformation.Email,loginInformation.Password)
+		if err != nil {
+			// 存在しないemailまたは適切なpasswordが入力されていない場合403を返す
+			errorMessage := ResponseMessage{Message: err.Error()}
+			c.JSON(403,errorMessage)
+		}else{
+			// 認証処理が成功の場合200を返す
+			message := ResponseMessage{Message: "ログインに成功しました"}
+			c.JSON(200, message)
+		}
 	}
 }

--- a/app/controller/user_controller.go
+++ b/app/controller/user_controller.go
@@ -25,7 +25,7 @@ type ResponseMessage struct {
 
 var (
 	// セッション情報を保存するためのマップ
-	sessions = make(map[string]bool)
+	sessions = make(map[string]string)
 	// セッション情報へのアクセスを同期するためのミューテックス
 	sessionMutex = &sync.Mutex{}
 )
@@ -71,7 +71,7 @@ func Login(c *gin.Context){
 		c.IndentedJSON(400, errorMessage)
 	}else{
 		//ログイン処理を呼び出す
-		err:=service.Login(loginInformation.Email,loginInformation.Password)
+		role,err:=service.Login(loginInformation.Email,loginInformation.Password)
 		if err != nil {
 			// 存在しないemailまたは適切なpasswordが入力されていない場合403を返す
 			errorMessage := ResponseMessage{Message: err.Error()}
@@ -86,7 +86,7 @@ func Login(c *gin.Context){
 
 			// セッションIDを保存する
 			sessionMutex.Lock()
-			sessions[sessionID] = true
+			sessions[sessionID] = role
 			sessionMutex.Unlock()
 
 			// Cookieをセットする

--- a/app/database/init/init_database.sql
+++ b/app/database/init/init_database.sql
@@ -101,8 +101,8 @@ CREATE TABLE IF NOT EXISTS equipment_reservations(
 
 -- usersテーブルにデータを挿入
 INSERT INTO users (name, email, password, user_icon, role) VALUES
-('John Doe', 'john@example.com', 'hashed_password', 'user_icon.jpg', 'admin'),
-('Jane Doe', 'jane@example.com', 'hashed_password', 'user_icon.jpg', 'user');
+('John Doe', 'john@example.com', '$2a$10$.Y2NV3z9RaupeC3F7ljvZOcXgkKQpN8dC8nj0VXnM9Nx6T9yOx502', 'user_icon.jpg', 'admin'),
+('Jane Doe', 'jane@example.com', '$2a$10$.Y2NV3z9RaupeC3F7ljvZOcXgkKQpN8dC8nj0VXnM9Nx6T9yOx502', 'user_icon.jpg', 'user');
 -- usersテーブルのデータを確認
 SELECT * FROM users;
 

--- a/app/model/user.go
+++ b/app/model/user.go
@@ -32,13 +32,13 @@ func GetUsers()(users []User){
 }
 
 // ユーザーを登録するためのメソッド
-// パスワードをデフォルトでpasswordに設定（仕様にて変更あり）
-func CreateUsers(name,email,role string)(){
+//　初期パスワードはハッシュ化したpasswordとする
+func CreateUsers(name,email,role string,password string)(){
 	user:=User{}
 	user.Name=name
 	user.Email=email
 	user.Role=role
-	user.Password="password"
+	user.Password=password
 	
 	result:=Db.Select("Name","Email","Role","Password").Create(&user)
 	if result.Error != nil {

--- a/app/model/user.go
+++ b/app/model/user.go
@@ -57,11 +57,11 @@ func IsEmail(email string) (users []User){
 }
 
 // emailからユーザー情報を取得するためのメソッド
-func GetUserPasswordByEmail(email string) (password string){
+func GetUserPasswordByEmail(email string) (password string,role string){
 	user:=User{}
-	result:=Db.Select("Password").Where("email=?",email).Find(&user)
+	result:=Db.Select("Password","Role").Where("email=?",email).Find(&user)
 	if result.Error != nil {
 		panic(result.Error)
 	}
-	return user.Password
+	return user.Password,user.Role
 }

--- a/app/model/user.go
+++ b/app/model/user.go
@@ -55,3 +55,13 @@ func IsEmail(email string) (users []User){
 	}
 	return
 }
+
+// emailからユーザー情報を取得するためのメソッド
+func GetUserPasswordByEmail(email string) (password string){
+	user:=User{}
+	result:=Db.Select("Password").Where("email=?",email).Find(&user)
+	if result.Error != nil {
+		panic(result.Error)
+	}
+	return user.Password
+}

--- a/app/service/user_service.go
+++ b/app/service/user_service.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"app/model"
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 //ユーザー一覧を取得するためのメソッド
@@ -13,11 +16,24 @@ func GetUsers() []model.User{
 
 //ユーザー登録するためのメソッド
 func CreateUsers(name,email,role string){
-	model.CreateUsers(name,email,role)
+	//初期パスワードをハッシュ化したpasswordとして生成
+	password:="password"
+	encryptPw,err:=PasswordEncrypt(password)
+	if err != nil {
+		fmt.Println("パスワード暗号化中にエラーが発生しました。：", err)
+		return
+	}
+	model.CreateUsers(name,email,role,encryptPw)
 }
 
 //メール重複を確認するためのメソッド
 func IsEmail(email string) bool{
 	user := model.IsEmail(email)
 	return len(user) == 0
+}
+
+// 暗号(Hash)化するためのメソッド
+func PasswordEncrypt(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	return string(hash), err
 }

--- a/app/service/user_service.go
+++ b/app/service/user_service.go
@@ -28,18 +28,18 @@ func CreateUsers(name,email,role string){
 }
 
 // ログイン処理のためのメソッド
-func Login(email string,password string)(error error){
+func Login(email string,password string)(role string,error error){
 	//　入力されたログイン情報から認証処理を実施する
 	// emailからユーザー情報（password）を取得する
-	userPassword :=model.GetUserPasswordByEmail(email)
+	userPassword,role :=model.GetUserPasswordByEmail(email)
 	if userPassword == "" {
-		return errors.New("存在しないメールアドレスです")
+		return "",errors.New("存在しないメールアドレスです")
 	}
 	err := CompareHashAndPassword(userPassword, password)
 	if err != nil {
-		return errors.New("パスワードが一致しませんでした")
+		return "",errors.New("パスワードが一致しませんでした")
 	}
-	return
+	return role,nil
 }
 
 //メール重複を確認するためのメソッド

--- a/app/service/user_service.go
+++ b/app/service/user_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"app/model"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
@@ -26,6 +27,21 @@ func CreateUsers(name,email,role string){
 	model.CreateUsers(name,email,role,encryptPw)
 }
 
+// ログイン処理のためのメソッド
+func Login(email string,password string)(error error){
+	//　入力されたログイン情報から認証処理を実施する
+	// emailからユーザー情報（password）を取得する
+	userPassword :=model.GetUserPasswordByEmail(email)
+	if userPassword == "" {
+		return errors.New("存在しないメールアドレスです")
+	}
+	err := CompareHashAndPassword(userPassword, password)
+	if err != nil {
+		return errors.New("パスワードが一致しませんでした")
+	}
+	return
+}
+
 //メール重複を確認するためのメソッド
 func IsEmail(email string) bool{
 	user := model.IsEmail(email)
@@ -36,4 +52,9 @@ func IsEmail(email string) bool{
 func PasswordEncrypt(password string) (string, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	return string(hash), err
+}
+
+// 暗号(Hash)と入力された平パスワードの比較
+func CompareHashAndPassword(hash, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 }


### PR DESCRIPTION
# 機能詳細
- ログイン機能（認証認可）
  - セッションIDを用いた認証処理を実装した
  - サーバーでセッションIDと権限情報を保持
  - ログイン成功時にsetCookieでセッションID（16バイトのランダムなバイト列）を保持させる
    > セッション保持時間は１時間に設定している（変更可能） 
  - ログインには`email`,`password`を使用している
  - `/api/admin`がパスに含まれている場合はadmin権限が必要
    > 今後の実装に支障があると考え、認可機能については`/api/admin/users`のみ実装している
    > メソッドを`r.GET("/api/admin/users",CheckAuth, GetUsers)`のように指定するだけで認可機能をパスごとに実装できる
    > 今後認可機能についてはまとめて実装ができるように別クラスに切り分けしたいと考えている
- ログアウト機能
  - Cookieからセッション情報を取得してサーバーサイドでセッションを削除する
  - setCookieでクライアントのセッションIDを削除する
- パスワードハッシュ化処理
  - 平文のパスワードをまずは暗号化（ハッシュ化）してユーザー登録できるよう修正した
  - 登録初期パスワードは`password`
  - 上記に伴いinitのパスワード値を変更しています（DB初期化お願いします）

# 実装確認
- 確認前に以下の2ユーザーを作成してください
> POSTで`http://localhost:8080/api/admin/users/create`以下をJSONとしてボディに入れてリクエストしてください
- admin権限
```
{
    "name": "John Doe",
    "email": "hoge@example.com",
    "role": "admin"
}
```
- user権限
```
{
    "name": "John Doe",
    "email": "hogehoge@example.com",
    "role": "user"
}
```

- ログイン処理
  - 認証処理（ POSTで`http://localhost:8080/api/login`以下をボディに入れる）
    - 成功時(セッションIDがクッキに保管されています）
      ```
      {
          "email":"hoge@example.com",
          "password":"password"
      }
      ```
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/5cf3dd20-e92b-4ecc-b890-8735a62090d4)

    - 失敗時(セッションIDがクッキに保管されていないです）
      ```
      {
          "email":"hoge@example.com",
          "password":"passwordpassword"
      }
      ```
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/3b6d194f-48c7-4b4b-bb9f-0092e5519633)

    - バリデーション時
      ```
      {
          "email":"hoge@example.com",
          "password":""
      }
      ```
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/990bc21e-3e52-451f-a8c2-e6303129b709)


  - 認可処理
    - adminユーザーが`/api/admin`を含むパスをリクエストした時
      - POSTで`http://localhost:8080/api/login`
      ```
      {
          "email":"hoge@example.com",
          "password":"password"
      }
      ```
      - GETで`http://localhost:8080/api/admin/users`
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/77b67849-b563-4bec-8e65-8b73b03681e7)

    - user権限のユーザーが`/api/admin`を含むパスをリクエストした時
      - POSTで`http://localhost:8080/api/login`
      ```
      {
          "email":"hogehoge@example.com",
          "password":"password"
      }
      ```
      - GETで`http://localhost:8080/api/admin/users`
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/30ceee29-ced6-4470-8a1c-486ab5d66fa1)

    - ログイン前に認可処理が必要なパスをリクエストした時
      - POSTで`http://localhost:8080/api/logout`
      - GETで`http://localhost:8080/api/admin/users`
      ![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/a9996096-8d6a-43ff-8c0b-a83528e8181f)

> user権限を持っているときには認可処理が必要なパスかつ`/api/admin`を含まないパスをリクエストした時に認可されます
> 池田の処理で上記の条件の処理がなかったので実装はしていないですが、`/api/equipments/`などの引数に`CheckAuth`メソッドを追加してuser権限ログイン後、リクエストしてみると確認できますが、ここでは割愛とさせていただきます。


- ログアウト処理
  - POSTで`http://localhost:8080/api/logout`
  - ログイン後、セッション情報がクッキーに設定されていることを確認する
![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/5922d731-0ee0-46ba-837f-f51ecec84521)
  - リクエスト後、クッキーがなくなっていることを確認する
![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/118358124/dcca9d60-6d7b-4e2d-b881-fb32e5b5c9d1)

# 共有事項
- 認可処理については各実装が終了次第、もしくは個々で実装をお願いします。