### PR TITLE
機材予約の変更機能　API

### DIFF
--- a/app/controller/equipment_controller.go
+++ b/app/controller/equipment_controller.go
@@ -82,3 +82,35 @@ func GetEquipmentById(c *gin.Context) {
 		})
 	}
 }
+
+/*
+機材予約を変更するメソッド
+リクエストコンテキストから機材予約情報を取得し、サービス層を介してデータベースの更新を試みる。
+正常に更新されたら、ステータスコード200と成功メッセージをJSONで返す。
+更新がエラーとなった場合は、ステータスコード404とエラーメッセージをJSONで返す。
+*/
+func changeEquipmentReservation(c *gin.Context) {
+	equipmentId := c.Param("equipmentId")
+	reserveId := c.Param("reserveId")
+
+	var equipmentReservingRequest request.EquipmentReservingRequest
+
+	if err := c.ShouldBindJSON(&equipmentReservingRequest); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	validate := validator.New()
+	err := validate.Struct(equipmentReservingRequest)
+	if err != nil {
+		c.IndentedJSON(404, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = service.ChangeEquipmentReservation(equipmentId, reserveId, equipmentReservingRequest)
+	if err != nil {
+		c.IndentedJSON(404, gin.H{"error": err.Error()})
+		return
+	}
+	c.IndentedJSON(200, gin.H{"message": "Changed equipment reservation successfully"})
+}

--- a/app/controller/router.go
+++ b/app/controller/router.go
@@ -23,6 +23,7 @@ func GetRouter() *gin.Engine {
 	r.GET("/api/admin/users", CheckAuth, GetUsers)
 	r.POST("/api/admin/users/create", CreateUsers)
 	r.POST("/api/equipments/:equipmentId/reserve", ReserveEquipment)
+	r.PUT("/api/equipments/:equipmentId/reserve/:reserveId", changeEquipmentReservation)
 	return r
 }
 

--- a/app/model/equipment.go
+++ b/app/model/equipment.go
@@ -1,10 +1,12 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"gorm.io/gorm"
 )
 
 // "gorm.io/gorm"
@@ -64,4 +66,38 @@ func GetEquipmentById(equipmentId int) (equipment Equipment) {
 		panic(result.Error)
 	}
 	return
+}
+
+// リクエストから受け取ったデータを使用し、機材予約を変更する
+func (newEquipmentReservation *EquipmentReservation) ChangeEquipmentReservation() error {
+	var equipmentReservationId = newEquipmentReservation.EquipmentReservationId
+	var equipmentId = newEquipmentReservation.EquipmentId
+
+	var existingReservation EquipmentReservation
+
+	// 該当の機材予約の存在チェック
+	if err := Db.Where("equipment_reservation_id = ? AND equipment_id = ? AND deleted_at IS NULL", equipmentReservationId, equipmentId).
+		First(&existingReservation).
+		Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("equipment reservation not found")
+		}
+		fmt.Print(err)
+		return fmt.Errorf("failed to find equipment reservation:")
+	}
+
+	// リクエストから受け取ったデータに更新
+	existingReservation.ReservationStartTime = newEquipmentReservation.ActivityStartTime
+	existingReservation.ReservationEndTime = newEquipmentReservation.ReservationEndTime
+	existingReservation.ActivityStartTime = newEquipmentReservation.ActivityStartTime
+	existingReservation.ActivityEndTime = newEquipmentReservation.ActivityEndTime
+
+	// 更新をデータベースに反映
+	if err := Db.Save(&existingReservation).
+		Error; err != nil {
+		fmt.Print(err)
+		return fmt.Errorf("failed to delete equipment reservation.")
+	}
+
+	return nil
 }

--- a/app/service/equipment_service.go
+++ b/app/service/equipment_service.go
@@ -61,6 +61,53 @@ func ReserveEquipment(equipmentIdStr string, reservingRequest request.EquipmentR
 	return nil
 }
 
+func ChangeEquipmentReservation(equipmentIdStr string, reserveIdStr string, reservingRequest request.EquipmentReservingRequest) error {
+	// equipmentId(string)をintに変換
+	equipmentId, err := strconv.Atoi(equipmentIdStr)
+	if err != nil {
+		return err
+	}
+	// reserveId(string)をintに変換
+	reserveId, err := strconv.Atoi(reserveIdStr)
+	if err != nil {
+		return err
+	}
+	// 各時間の変換
+	reservationStartTime, err := StrToTime(reservingRequest.ReservationStartTime)
+	if err != nil {
+		return err
+	}
+	reservationEndTime, err := StrToTime(reservingRequest.ReservationEndTime)
+	if err != nil {
+		return err
+	}
+	activityStartTime, err := StrToTime(reservingRequest.ActivityStartTime)
+	if err != nil {
+		return err
+	}
+	activityEndTime, err := StrToTime(reservingRequest.ActivityEndTime)
+	if err != nil {
+		return err
+	}
+
+	equipmentReservation := model.EquipmentReservation{
+		EquipmentReservationId: uint(reserveId),
+		EquipmentId:            equipmentId,
+		ReservationStartTime:   reservationStartTime,
+		ReservationEndTime:     reservationEndTime,
+		ActivityStartTime:      activityStartTime,
+		ActivityEndTime:        activityEndTime,
+	}
+
+	err = equipmentReservation.ChangeEquipmentReservation()
+	if err != nil {
+		return err
+	}
+
+	// 処理の中でエラーが発生しなかった場合、nilを返す。
+	return nil
+}
+
 // 日時(string)をtime.Time型に変換する関数
 func StrToTime(dateStr string) (time.Time, error) {
 	date, err := time.Parse(time.RFC3339, dateStr)

--- a/app/service/equipment_service.go
+++ b/app/service/equipment_service.go
@@ -110,7 +110,7 @@ func ChangeEquipmentReservation(equipmentIdStr string, reserveIdStr string, rese
 
 // 日時(string)をtime.Time型に変換する関数
 func StrToTime(dateStr string) (time.Time, error) {
-	date, err := time.Parse(time.RFC3339, dateStr)
+	date, err := time.Parse("2006-01-02 15:04:05", dateStr)
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
# 機能詳細
- 機材予約の内容を変更する。
- PUT　/api/equipments/:equipmentId/reserve/:reserveId
- 更新対象の条件として、equipmentId と　reserveId の合致し、且つ、deleted_atがnullのものとする。
- リクエストデータ
```
{
    "userId": 1,
    "reservationStartTime": "2022-02-23T15:00:00Z",
	"reservationEndTime": "2022-02-23T18:00:00Z",
	"activityStartTime": "2022-02-23T15:00:00Z",
	"activityEndTime": "2022-02-23T17:00:00Z"
}
```
# 実装確認
- 正常時
![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/131426881/194cce65-31c6-4239-9c96-4e16908317c9)
- 異常時（合致するレコードが無い）
![image](https://github.com/tetsu-777/rakuraku-reserve-app/assets/131426881/088179ea-c107-47a8-9d33-a5dc81337220)
- 異常時（リクエストデータに欠陥　バリデーションエラー）
<img width="867" alt="image" src="https://github.com/tetsu-777/rakuraku-reserve-app/assets/131426881/d3aea8ac-5c87-4b75-b75f-155f69614c77">

# 共有事項
- 特になし
